### PR TITLE
Add support link to footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,5 +104,7 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/
       name: GitHub
+  footer: |
+    Need support using the cookbook? Visit <a href="https://support.playrugbyleague.com" target="_blank" rel="noopener">support.playrugbyleague.com</a>.
 extra_css:
   - assets/styles/custom.css


### PR DESCRIPTION
## Summary
- add a site footer message linking to support.playrugbyleague.com so users can find help using the cookbook

## Testing
- Not run (mkdocs not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e60fea3474832d9e5505c642cfe95b